### PR TITLE
Check if the environment varialbe for exiftool path exists before using

### DIFF
--- a/micasense/imageset.py
+++ b/micasense/imageset.py
@@ -59,9 +59,9 @@ class ImageSet(object):
 
         images = []
 
-        if exiftool_path is None:
+        if exiftool_path is None and os.environ.get('exiftoolpath') is not None:
             exiftool_path = os.path.normpath(os.environ.get('exiftoolpath'))
-        
+
         with exiftool.ExifTool(exiftool_path) as exift:
             for i,path in enumerate(matches):
                 images.append(image.Image(path, exiftool_obj=exift))


### PR DESCRIPTION
This fixed the issue described in #42 for me on linux where exiftool is on the system path and doesn't need to be set via environment variable.