### PR TITLE
This addresses #47 more explicitly and adds some tests to ensure the …

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,3 +139,7 @@ def meta_v3():
 def meta_bad_exposure():
     image_path = os.path.join('data', '0001SET', '000')
     return metadata.Metadata(os.path.join(image_path, 'IMG_0003_1.tif'))
+
+@pytest.fixture()
+def meta_altum_dls2(altum_flight_image_name):
+    return metadata.Metadata(altum_flight_image_name)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -126,3 +126,9 @@ def test_good_exposure_v3(meta_v3):
 
 def test_bad_exposure_time(meta_bad_exposure):
     assert meta_bad_exposure.exposure() == pytest.approx(247e-6, abs=1e-3)
+
+def test_dls1_scale_factor(meta):
+    assert meta.irradiance_scale_factor() == pytest.approx(1.0)
+
+def test_dls2_scale_factor(meta_altum_dls2):
+    assert meta_altum_dls2.irradiance_scale_factor() == pytest.approx(0.01)


### PR DESCRIPTION
Per #47:

For cameras with DLS2, the scale factor for all irradiance tags has changed. For DLS1, the units were the SI standard W/m^2/nm.  For current DLS2 data, the units are uW/cm^2/nm.  This results in a scale difference of 100 between the two unit sets.  Altum or RedEdge doesn't matter - the difference is DLS1 vs DLS2.  This was ultimately an unintentional change, as we strongly prefer SI units, but we had some calibration software and validation software that was canceling this change so we didn't notice until recently.  

This updates the altum-support branch to handle the change properly.

If the image metadata has a HorizontalIrradiance tag, but no IrradianceScaleToSIUnits tag, you should multiply the SpectralIrradiance and HorizontalIrradiance by 0.01 (divide by 100) to get to W/m2/nm.  If there is an IrradianceScaleToSIUnits tag, then you should scale the data by that tag.  We haven't released a firmware that has the IrradianceScaleToSIUnits tag, but will likely do so in the future. Employing the logic below will future-proof the change you make now.