### PR TITLE
Fix horizontal irradiance calculation for the proper solar_elevation …

### DIFF
--- a/micasense/image.py
+++ b/micasense/image.py
@@ -163,6 +163,11 @@ class Image(object):
         self.__undistorted_source = None # can be any of raw, intensity, radiance
         self.__undistorted_image = None # current undistorted image, depdining on source
 
+    # solar elevation is defined as the angle betwee the horizon and the sun, so it is 0 when the 
+    # sun is at the horizon and pi/2 when the sun is directly overhead
+    def horizontal_irradiance_from_direct_scattered(self):
+        return self.direct_irradiance * np.sin(self.solar_elevation) + self.scattered_irradiance
+
     def compute_horizontal_irradiance_dls1(self):
         percent_diffuse = 1.0/self.direct_to_diffuse_ratio
         #percent_diffuse = 5e4/(img.center_wavelength**2)
@@ -172,9 +177,7 @@ class Image(object):
         self.direct_irradiance = untilted_direct_irr
         self.scattered_irradiance = untilted_direct_irr*percent_diffuse
         # compute irradiance on the ground using the solar altitude angle
-        ground_irr = untilted_direct_irr * (percent_diffuse + np.sin(self.solar_elevation))
-
-        return ground_irr
+        return self.horizontal_irradiance_from_direct_scattered()
     
     def compute_horizontal_irradiance_dls2(self):
         ''' Compute the proper solar elevation, solar azimuth, and horizontal irradiance 
@@ -185,7 +188,7 @@ class Image(object):
                                         (0,0,0),
                                         self.utc_time,
                                         np.array([0,0,-1]))
-        return self.direct_irradiance*np.cos(self.solar_elevation) + self.scattered_irradiance
+        return self.horizontal_irradiance_from_direct_scattered()
 
     def __lt__(self, other):
         return self.band_index < other.band_index

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -107,12 +107,18 @@ def test_altum_lwir_image(altum_lwir_image):
 
 def test_altum_image_horizontal_irradiance(altum_flight_image):
     assert altum_flight_image.dls_present
-    good_horiz_irradiance = 1.222
+    solar_el = altum_flight_image.solar_elevation
+    direct_irr = altum_flight_image.direct_irradiance
+    scattered_irr = altum_flight_image.scattered_irradiance
+    good_horiz_irradiance = direct_irr * np.sin(solar_el) + scattered_irr
     assert altum_flight_image.horizontal_irradiance == pytest.approx(good_horiz_irradiance, 1e-3)
 
 def test_altum_bad_dls2_horizontal_irradiance(bad_dls2_horiz_irr_image):
     assert bad_dls2_horiz_irr_image.dls_present
     assert bad_dls2_horiz_irr_image.meta.horizontal_irradiance_valid() == False
-    good_horiz_irradiance = 1.318
+    solar_el = bad_dls2_horiz_irr_image.solar_elevation
+    direct_irr = bad_dls2_horiz_irr_image.direct_irradiance
+    scattered_irr = bad_dls2_horiz_irr_image.scattered_irradiance
+    good_horiz_irradiance = direct_irr * np.sin(solar_el) + scattered_irr
     assert bad_dls2_horiz_irr_image.horizontal_irradiance == pytest.approx(good_horiz_irradiance, 1e-3)
 


### PR DESCRIPTION
…convention.

Had a cos where we needed a sin due to a previously different elevation convention. DRY up the computation to use the same equation.