### PR TITLE
Limit exposure correction to RedEdge and tighten the tolerance

### DIFF
--- a/micasense/metadata.py
+++ b/micasense/metadata.py
@@ -177,8 +177,10 @@ class Metadata(object):
 
     def exposure(self):
         exp = self.get_item('EXIF:ExposureTime')
-        if math.fabs(exp-(1.0/6329.0)) < 0.0001:
-            exp = 0.000274
+        # correct for incorrect exposure in some legacy RedEdge firmware versions
+        if self.camera_model() != "Altum":
+            if math.fabs(exp-(1.0/6329.0)) < 1e-6: 
+                exp = 0.000274
         return exp
 
     def gain(self):


### PR DESCRIPTION
The metadata 'correction' in the `exposure` method is present due to a bug in legacy RedEdge firmwares which reported an incorrect exposure time.  In those cases the bad reported exposure would be exactly 1/6329 seconds.  In this code, a floating point compare was checking for any exposure within 1ms of the magic number, but this allowed more exposures than desired, especially for short exposure times. This change limits that comparison to not include Altum cameras and to require it to be within 1usec of the expected time.