### PR TITLE
Support 12-bit imagery using rawpy

### DIFF
--- a/micasense/image.py
+++ b/micasense/image.py
@@ -209,6 +209,9 @@ class Image(object):
         ''' Lazy load the raw image once neecessary '''
         if self.__raw_image is None:
             try:
+                import rawpy
+                self.__raw_image = rawpy.imread(self.path).raw_image
+            except ImportError:
                 self.__raw_image = cv2.imread(self.path,-1)
             except IOError:
                 print("Could not open image at path {}".format(self.path))

--- a/micasense_conda_env.yml
+++ b/micasense_conda_env.yml
@@ -24,3 +24,4 @@ dependencies:
     - mapboxgl
     - git+https://github.com/smarnach/pyexiftool.git#egg=pyexiftoolpy
     - jenkspy
+    - rawpy


### PR DESCRIPTION
Support 12-bit by using rawpy by default per 78. If rawpy fails to import, use openCV (which only supports 16-bit images).