### PR TITLE
Bug/75 incorrect cropping

### DIFF
--- a/micasense/capture.py
+++ b/micasense/capture.py
@@ -415,14 +415,14 @@ class Capture(object):
         else:
             imageio.imwrite(outfilename, (255*unsharp_rgb).astype('uint8'))
     
-    def save_thermal_over_rgb(self, outfilename):
+    def save_thermal_over_rgb(self, outfilename, figsize=(30,23)):
         if self.__aligned_capture is None:
             raise RuntimeError("call Capture.create_aligned_capture prior to saving as RGB")
         
         # by default we don't mask the thermal, since it's native resolution is much lower than the MS
         masked_thermal = self.__aligned_capture[:,:,5]
         
-        im_display = np.zeros((self.__aligned_capture.shape[0],self.__aligned_capture.shape[1],self.__aligned_capture.shape[2]), dtype=np.float32 )
+        im_display = np.zeros((self.__aligned_capture.shape[0],self.__aligned_capture.shape[1],3), dtype=np.float32 )
         rgb_band_indices = [2,1,0]
         hist_min_percent = 0.2
         hist_max_percent = 99.8
@@ -430,8 +430,8 @@ class Capture(object):
         # maintain the "white balance" of the calibrated image  
         im_min = np.percentile(self.__aligned_capture[:,:,rgb_band_indices].flatten(), hist_min_percent)  # modify these percentiles to adjust contrast
         im_max = np.percentile(self.__aligned_capture[:,:,rgb_band_indices].flatten(), hist_max_percent)  # for many images, 0.5 and 99.5 are good values
-        for i in rgb_band_indices:
-            im_display[:,:,i] =  imageutils.normalize(self.__aligned_capture[:,:,i], im_min, im_max)
+        for dst_band,src_band in enumerate(rgb_band_indices):
+            im_display[:,:,dst_band] =  imageutils.normalize(self.__aligned_capture[:,:,src_band], im_min, im_max)
        
         # Compute a histogram
         min_display_therm = np.percentile(masked_thermal, 1)
@@ -448,5 +448,6 @@ class Capture(object):
                                             display_contours=True,
                                             contour_steps=16,
                                             contour_alpha=.4,
-                                            contour_fmt="%.0fC")
+                                            contour_fmt="%.0fC",
+                                            show=False)
         fig.savefig(outfilename)

--- a/micasense/capture.py
+++ b/micasense/capture.py
@@ -379,9 +379,7 @@ class Capture(object):
             outband.FlushCache()
         outRaster = None
 
-    def save_capture_as_rgb(self, outfilename, gamma=1.4, downsample=1, white_balance='norm', hist_min_percent=0.5, hist_max_percent=99.5, sharpen=True):
-        rgb_band_indices = [2,1,0]
-        
+    def save_capture_as_rgb(self, outfilename, gamma=1.4, downsample=1, white_balance='norm', hist_min_percent=0.5, hist_max_percent=99.5, sharpen=True, rgb_band_indices = [2,1,0]):        
         if self.__aligned_capture is None:
             raise RuntimeError("call Capture.create_aligned_capture prior to saving as RGB")
         im_display = np.zeros((self.__aligned_capture.shape[0],self.__aligned_capture.shape[1],self.__aligned_capture.shape[2]), dtype=np.float32 )
@@ -416,3 +414,39 @@ class Capture(object):
             imageio.imwrite(outfilename, (255*gamma_corr_rgb).astype('uint8'))
         else:
             imageio.imwrite(outfilename, (255*unsharp_rgb).astype('uint8'))
+    
+    def save_thermal_over_rgb(self, outfilename):
+        if self.__aligned_capture is None:
+            raise RuntimeError("call Capture.create_aligned_capture prior to saving as RGB")
+        
+        # by default we don't mask the thermal, since it's native resolution is much lower than the MS
+        masked_thermal = self.__aligned_capture[:,:,5]
+        
+        im_display = np.zeros((self.__aligned_capture.shape[0],self.__aligned_capture.shape[1],self.__aligned_capture.shape[2]), dtype=np.float32 )
+        rgb_band_indices = [2,1,0]
+        hist_min_percent = 0.2
+        hist_max_percent = 99.8
+        # for rgb true color, we usually want to use the same min and max scaling across the 3 bands to 
+        # maintain the "white balance" of the calibrated image  
+        im_min = np.percentile(self.__aligned_capture[:,:,rgb_band_indices].flatten(), hist_min_percent)  # modify these percentiles to adjust contrast
+        im_max = np.percentile(self.__aligned_capture[:,:,rgb_band_indices].flatten(), hist_max_percent)  # for many images, 0.5 and 99.5 are good values
+        for i in rgb_band_indices:
+            im_display[:,:,i] =  imageutils.normalize(self.__aligned_capture[:,:,i], im_min, im_max)
+       
+        # Compute a histogram
+        min_display_therm = np.percentile(masked_thermal, 1)
+        max_display_therm = np.percentile(masked_thermal, 99)
+
+        fig, axis = plotutils.plot_overlay_withcolorbar(im_display,
+                                            masked_thermal, 
+                                            figsize=figsize, 
+                                            title='Temperature over True Color',
+                                            vmin=min_display_therm,vmax=max_display_therm,
+                                            overlay_alpha=0.25,
+                                            overlay_colormap='jet',
+                                            overlay_steps=16,
+                                            display_contours=True,
+                                            contour_steps=16,
+                                            contour_alpha=.4,
+                                            contour_fmt="%.0fC")
+        fig.savefig(outfilename)

--- a/micasense/imageutils.py
+++ b/micasense/imageutils.py
@@ -157,7 +157,7 @@ def align(pair):
                 plotutils.plotwithcolorbar(grad2, "match grad level {}".format(level))
                 print("Starting warp for level {} is:\n {}".format(level,warp_matrix))
 
-            cc, warp_matrix = cv2.findTransformECC(grad1, grad2, warp_matrix, warp_mode, criteria)
+            cc, warp_matrix = cv2.findTransformECC(grad1, grad2, warp_matrix, warp_mode, criteria, inputMask=None, gaussFiltSize=1)
 
             if show_debug_images:
                 print("Warp after alignment level {} is \n{}".format(level,warp_matrix))
@@ -320,14 +320,14 @@ def find_crop_bounds(capture,registration_transforms,warp_mode=cv2.MOTION_HOMOGR
     lens_distortions = [image.cv2_distortion_coeff() for image in capture.images]
     camera_matrices =  [image.cv2_camera_matrix() for image in capture.images]
 
-    bounds = [get_inner_rect(s, a, d, c,warp_mode=warp_mode)[0] for s,a, d, c in zip(image_sizes,registration_transforms, lens_distortions, camera_matrices)]
-    edges = [get_inner_rect(s, a, d, c,warp_mode=warp_mode)[1] for s,a, d, c in zip(image_sizes,registration_transforms, lens_distortions, camera_matrices)]
+    bounds = [get_inner_rect(s, a, d, c,warp_mode=warp_mode)[0] for s, a, d, c in zip(image_sizes,registration_transforms, lens_distortions, camera_matrices)]
+    edges = [get_inner_rect(s, a, d, c,warp_mode=warp_mode)[1] for s, a, d, c in zip(image_sizes,registration_transforms, lens_distortions, camera_matrices)]
     combined_bounds = get_combined_bounds(bounds, image_sizes[0])
 
-    left = round(combined_bounds.min.x)
-    top = round(combined_bounds.min.y)
-    width = round(combined_bounds.max.x - combined_bounds.min.x + 0.5)
-    height = round(combined_bounds.max.y - combined_bounds.min.y + 0.5)
+    left = np.ceil(combined_bounds.min.x)
+    top = np.ceil(combined_bounds.min.y)
+    width = np.floor(combined_bounds.max.x - combined_bounds.min.x)
+    height = np.floor(combined_bounds.max.y - combined_bounds.min.y)
     return (left, top, width, height),edges
 
 def get_inner_rect(image_size, affine, distortion_coeffs, camera_matrix,warp_mode=cv2.MOTION_HOMOGRAPHY):
@@ -399,8 +399,6 @@ def min_max(pts):
     return bounds
 
 def map_points(pts, image_size, warpMatrix, distortion_coeffs, camera_matrix,warp_mode=cv2.MOTION_HOMOGRAPHY):
-    #assert len(affine) == 6, "affine must have len == 6, has len {}".format(len(affine))
-
     # extra dimension makes opencv happy
     pts = np.array([pts], dtype=np.float)
 

--- a/micasense/imageutils.py
+++ b/micasense/imageutils.py
@@ -157,8 +157,11 @@ def align(pair):
                 plotutils.plotwithcolorbar(grad2, "match grad level {}".format(level))
                 print("Starting warp for level {} is:\n {}".format(level,warp_matrix))
 
-            cc, warp_matrix = cv2.findTransformECC(grad1, grad2, warp_matrix, warp_mode, criteria, inputMask=None, gaussFiltSize=1)
-
+            try:
+                cc, warp_matrix = cv2.findTransformECC(grad1, grad2, warp_matrix, warp_mode, criteria, inputMask=None, gaussFiltSize=1)
+            except TypeError:
+                cc, warp_matrix = cv2.findTransformECC(grad1, grad2, warp_matrix, warp_mode, criteria)
+            
             if show_debug_images:
                 print("Warp after alignment level {} is \n{}".format(level,warp_matrix))
 
@@ -401,11 +404,14 @@ def min_max(pts):
 def map_points(pts, image_size, warpMatrix, distortion_coeffs, camera_matrix,warp_mode=cv2.MOTION_HOMOGRAPHY):
     # extra dimension makes opencv happy
     pts = np.array([pts], dtype=np.float)
-
     new_cam_mat, _ = cv2.getOptimalNewCameraMatrix(camera_matrix, distortion_coeffs, image_size, 1)
     new_pts = cv2.undistortPoints(pts, camera_matrix, distortion_coeffs, P=new_cam_mat)
     if warp_mode == cv2.MOTION_AFFINE:
         new_pts = cv2.transform(new_pts, cv2.invertAffineTransform(warpMatrix))
     if warp_mode == cv2.MOTION_HOMOGRAPHY:
         new_pts =cv2.perspectiveTransform(new_pts,np.linalg.inv(warpMatrix).astype(np.float32))
-    return new_pts[0]
+    #apparently the output order has changed in 4.1.1 (possibly earlier from 3.4.3)
+    if cv2.__version__<='3.4.4':
+        return new_pts[0]
+    else:
+        return new_pts[:,0,:]

--- a/micasense/panel.py
+++ b/micasense/panel.py
@@ -81,7 +81,7 @@ class Panel(object):
         decoded = pyzbar.decode(self.gray8b, symbols=[pyzbar.ZBarSymbol.QRCODE])
         for symbol in decoded:
             serial_str = symbol.data.decode('UTF-8')
-            m = re.search('RP\d{2}-(\d{7})-\D{2}', serial_str)
+            m = re.search(r'RP\d{2}-(\d{7})-\D{2}', serial_str)
             if m:
                 self.serial = serial_str
                 self.panel_version = int(self.serial[2:4])

--- a/micasense_conda_env.yml
+++ b/micasense_conda_env.yml
@@ -1,9 +1,9 @@
-name: micasense_test
+name: micasense
 channels:
   - conda-forge
 dependencies:
   - python=3
-  - opencv<3.4.7
+  - opencv
   - numpy
   - jupyter
   - matplotlib

--- a/micasense_conda_env.yml
+++ b/micasense_conda_env.yml
@@ -1,9 +1,9 @@
-name: micasense
+name: micasense_test
 channels:
   - conda-forge
 dependencies:
   - python=3
-  - opencv=3
+  - opencv<3.4.7
   - numpy
   - jupyter
   - matplotlib

--- a/tests/test_imageutils.py
+++ b/tests/test_imageutils.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""
+Test imageutils functionality
+
+Copyright 2017 MicaSense, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+
+import pytest
+import os, glob
+import cv2
+
+import micasense.imageset as imageset
+import micasense.capture as capture
+import micasense.image as image
+import micasense.imageutils as imageutils
+
+from numpy import array
+from numpy import float32
+
+truth_warp_matrices = [array([[ 1.00523243e+00, -3.95214025e-03, -1.02620616e+01],
+       [ 2.48925470e-03,  1.00346483e+00,  4.17114294e+01],
+       [ 7.86653480e-07, -2.04642746e-06,  1.00000000e+00]]), array([[1., 0., 0.],
+       [0., 1., 0.],
+       [0., 0., 1.]]), array([[ 9.98681616e-01, -4.56952788e-03, -2.08530561e+00],
+       [ 4.63740524e-03,  9.96737324e-01,  3.19011722e+01],
+       [ 1.48930038e-06, -1.05003201e-06,  1.00000000e+00]]), array([[ 1.00149509e+00, -1.56960584e-03, -3.80940807e+00],
+       [ 2.11523967e-03,  1.00222122e+00,  4.78563536e+01],
+       [ 5.63914024e-07,  1.03391312e-07,  1.00000000e+00]]), array([[ 1.00305493e+00, -2.82497954e-03, -1.02199199e+01],
+       [ 3.23661267e-03,  1.00139925e+00,  1.50062440e+01],
+       [ 1.63746543e-06, -8.01922991e-07,  1.00000000e+00]]), array([[ 6.35209892e-02,  1.17877689e-05,  1.40322785e+01],
+       [-4.56733969e-04,  6.35520044e-02,  1.15592432e+01],
+       [-4.15804231e-06, -2.63551964e-06,  1.00000000e+00]])]
+
+truth_image_sizes = [(2064, 1544), (2064, 1544), (2064, 1544), (2064, 1544), (2064, 1544), (160, 120)]
+
+truth_lens_distortions = [array([-1.360334e-01,  2.374279e-01,  1.761687e-04,  2.373747e-04,
+       -1.304408e-01]), array([-1.458199e-01,  2.681765e-01,  2.403470e-04, -6.698399e-04,
+       -2.014740e-01]), array([-1.482020e-01,  2.494987e-01,  4.884159e-04, -1.989958e-04,
+       -1.674770e-01]), array([-1.516688e-01,  2.483217e-01,  9.426709e-04,  1.109110e-04,
+       -1.619578e-01]), array([-1.487282e-01,  2.477914e-01,  1.381469e-04,  5.226758e-04,
+       -1.687072e-01]), array([-3.869621e-01,  4.784228e-01,  3.671945e-03,  4.130745e-04,
+       -4.892879e-01])]
+
+truth_camera_matrices = [array([[2.24343510e+03, 0.00000000e+00, 1.01295942e+03],
+       [0.00000000e+00, 2.24343510e+03, 7.67547825e+02],
+       [0.00000000e+00, 0.00000000e+00, 1.00000000e+00]]), array([[2.23882015e+03, 0.00000000e+00, 1.01802029e+03],
+       [0.00000000e+00, 2.23882015e+03, 7.30214492e+02],
+       [0.00000000e+00, 0.00000000e+00, 1.00000000e+00]]), array([[2.23464845e+03, 0.00000000e+00, 1.01673333e+03],
+       [0.00000000e+00, 2.23464845e+03, 7.58373912e+02],
+       [0.00000000e+00, 0.00000000e+00, 1.00000000e+00]]), array([[2.24700170e+03, 0.00000000e+00, 1.01524638e+03],
+       [0.00000000e+00, 2.24700170e+03, 7.80426086e+02],
+       [0.00000000e+00, 0.00000000e+00, 1.00000000e+00]]), array([[2.24418040e+03, 0.00000000e+00, 1.01343188e+03],
+       [0.00000000e+00, 2.24418040e+03, 7.45014492e+02],
+       [0.00000000e+00, 0.00000000e+00, 1.00000000e+00]]), array([[162.63769993,   0.        ,  78.2788333 ],
+       [  0.        , 162.63769993,  56.92766664],
+       [  0.        ,   0.        ,   1.        ]])]
+
+def test_image_properties(non_panel_altum_capture):
+    for i,image in enumerate(non_panel_altum_capture.images):
+        assert(image.size() == pytest.approx(truth_image_sizes[i]))
+        assert(image.cv2_distortion_coeff() == pytest.approx(truth_lens_distortions[i]))
+        assert(image.cv2_camera_matrix() == pytest.approx(truth_camera_matrices[i]))
+
+def test_warp_matrices(non_panel_altum_capture):
+    warp_matrices = non_panel_altum_capture.get_warp_matrices()
+    for index,warp_matrix in enumerate(warp_matrices):
+        assert(warp_matrix == pytest.approx(truth_warp_matrices[index]))
+
+def test_cropping(non_panel_altum_capture):
+    warp_mode = cv2.MOTION_HOMOGRAPHY
+    warp_matrices = non_panel_altum_capture.get_warp_matrices()
+    cropped_dimensions,edges = imageutils.find_crop_bounds(non_panel_altum_capture,warp_matrices)
+    assert(cropped_dimensions == (21.0, 12.0, 2036.0, 1468.0))
+
+
+
+progress_val = 0.0
+def progress(p):
+    global progress_val
+    progress_val = p

--- a/tests/test_imageutils.py
+++ b/tests/test_imageutils.py
@@ -74,6 +74,8 @@ truth_camera_matrices = [array([[2.24343510e+03, 0.00000000e+00, 1.01295942e+03]
        [  0.        , 162.63769993,  56.92766664],
        [  0.        ,   0.        ,   1.        ]])]
 
+expected_dimensions = (21.0, 12.0, 2035.0, 1467.0)
+
 def test_image_properties(non_panel_altum_capture):
     for i,image in enumerate(non_panel_altum_capture.images):
         assert(image.size() == pytest.approx(truth_image_sizes[i]))
@@ -89,7 +91,7 @@ def test_cropping(non_panel_altum_capture):
     warp_mode = cv2.MOTION_HOMOGRAPHY
     warp_matrices = non_panel_altum_capture.get_warp_matrices()
     cropped_dimensions,edges = imageutils.find_crop_bounds(non_panel_altum_capture,warp_matrices)
-    assert(cropped_dimensions == (21.0, 12.0, 2036.0, 1468.0))
+    assert(cropped_dimensions == expected_dimensions)
 
 
 


### PR DESCRIPTION
Fix incorrect cropping that cropped up between opencv 3.4.4 and 3.4.7, as well as findTransformECC api change. Added tests for this change.

Recommended to do if you already have the code checked out (but shouldn't be required):
```
conda env update --file micasense_conda_env.yml
```