### PR TITLE
New save capture fuction

### DIFF
--- a/micasense/capture.py
+++ b/micasense/capture.py
@@ -412,6 +412,39 @@ class Capture(object):
         finally:
             outRaster = None
 
+
+    def save_bands_in_separate_file(self, outfilename, sort_by_wavelength=False,photometric='MINISBLACK'):
+        from osgeo.gdal import GetDriverByName, GDT_UInt16
+        if self.__aligned_capture is None:
+            raise RuntimeError("call Capture.create_aligned_capture prior to saving as stack")
+        rows, cols, bands = self.__aligned_capture.shape
+        driver = GetDriverByName('GTiff')      
+        
+        for i in range(0,5):
+            band_number = str(i+1)
+            outRaster = driver.Create(outfilename+'_'+band_number+'.tif', cols, rows, 1, GDT_UInt16, 
+                                  options = [ 'INTERLEAVE=BAND','COMPRESS=DEFLATE',f'PHOTOMETRIC={photometric}'])
+            outband = outRaster.GetRasterBand(1)
+            outdata = self.__aligned_capture[:,:,i]
+            outdata = outdata*32768
+            outdata[outdata<0] = 0
+            outdata[outdata>65535] = 65535
+            outband.WriteArray(outdata) 
+            outband.FlushCache()
+            outRaster = None
+
+        if bands == 6:
+            thermalRaster = driver.Create(outfilename+'_6.tif', cols, rows, 1, GDT_UInt16, 
+                                    options = [ 'INTERLEAVE=BAND','COMPRESS=DEFLATE',f'PHOTOMETRIC={photometric}'])
+            outband = thermalRaster.GetRasterBand(1)
+            outdata = (self.__aligned_capture[:,:,5]) * 100 
+            outdata[outdata<0] = 0
+            outdata[outdata>65535] = 65535
+            outband.WriteArray(outdata)
+            outband.FlushCache()
+            thermalRaster = None   
+
+
     def save_capture_as_rgb(self, outfilename, gamma=1.4, downsample=1, white_balance='norm', hist_min_percent=0.5, hist_max_percent=99.5, sharpen=True, rgb_band_indices = [2,1,0]):
         if self.__aligned_capture is None:
             raise RuntimeError("call Capture.create_aligned_capture prior to saving as RGB")
@@ -487,3 +520,6 @@ class Capture(object):
                                             contour_fmt="%.0fC",
                                             show=False)
         fig.savefig(outfilename)
+
+    
+


### PR DESCRIPTION
Proposed new function to save processed/aligned captures in separate tifs (per spectral band) instead of stacked tif. This was useful for me because OpenDroneMap did not read the stacked tif as input to assemble the orthomosaic. This function is based on micasense save_capture_as_stack.