### PR TITLE
Add Panel.ordered_panel_coordinates() method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ before_install:
   # install library dependencies
   - sudo apt-get install libzbar0 make perl
   # Install exiftool
-  - wget https://www.sno.phy.queensu.ca/~phil/exiftool/Image-ExifTool-11.76.tar.gz
-  - tar -xzf Image-ExifTool-11.76.tar.gz 
-  - pushd Image-ExifTool-11.76/
+  - wget https://exiftool.org/Image-ExifTool-12.01.tar.gz
+  - tar -xzf Image-ExifTool-12.01.tar.gz 
+  - pushd Image-ExifTool-12.01/
   - perl Makefile.PL 
   - make test
   - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ before_install:
   # install library dependencies
   - sudo apt-get install libzbar0 make perl
   # Install exiftool
-  - wget https://exiftool.org/Image-ExifTool-12.01.tar.gz
-  - tar -xzf Image-ExifTool-12.01.tar.gz 
-  - pushd Image-ExifTool-12.01/
+  - wget https://www.sno.phy.queensu.ca/~phil/exiftool/Image-ExifTool-11.76.tar.gz
+  - tar -xzf Image-ExifTool-11.76.tar.gz 
+  - pushd Image-ExifTool-11.76/
   - perl Makefile.PL 
   - make test
   - sudo make install

--- a/micasense/panel.py
+++ b/micasense/panel.py
@@ -191,6 +191,25 @@ class Panel(object):
         self.__panel_bounds = bounds[idx]
         return self.__panel_bounds
 
+    def ordered_panel_coordinates(self):
+        """
+        Return panel region coordinates in a predictable order. Panel region coordinates that are automatically
+        detected by the camera are ordered differently than coordinates detected by Panel.panel_corners().
+        :return: [ (ur), (ul), (ll), (lr) ] to mirror Image.panel_region attribute order
+        """
+        pc = self.panel_corners()
+        pc = sorted(pc, key=lambda x: x[0])
+
+        # get the coordinates on the "left" and "right" side of the bounding box
+        left_coords = pc[:2]
+        right_coords = pc[2:]
+
+        # sort y values ascending for correct order
+        left_coords = sorted(left_coords, key=lambda y: y[0])
+        right_coords = sorted(right_coords, key=lambda y: y[0])
+
+        return [tuple(right_coords[1]), tuple(left_coords[1]), tuple(left_coords[0]), tuple(right_coords[0])]
+
     def region_stats(self, img, region, sat_threshold=None):
         """Provide regional statistics for a image over a region
         Inputs: img is any image ndarray, region is a skimage shape

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -140,3 +140,21 @@ def test_altum_lwir(altum_lwir_image_name):
     assert img.auto_calibration_image == False
     pan = panel.Panel(img)
     assert pan.panel_detected() == False
+
+
+def test_ordered_coordinates(panel_image_name):
+    img = image.Image(panel_image_name)
+    if img.panel_region is not None:
+        ordered_corners = img.panel_region
+    else:
+        ordered_corners = [(809, 613), (648, 615), (646, 454), (808, 452)]
+    pan = panel.Panel(img, panelCorners=ordered_corners)
+    assert pan.ordered_panel_coordinates() == ordered_corners
+
+
+def test_unordered_coordinates(panel_image_name):
+    img = image.Image(panel_image_name)
+    ordered_corners = [(809, 613), (648, 615), (646, 454), (808, 452)]
+    unordered_corners = [(648, 615), (809, 613), (808, 452), (646, 454)]
+    pan = panel.Panel(img, panelCorners=unordered_corners)
+    assert pan.ordered_panel_coordinates() == ordered_corners

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -24,10 +24,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 import pytest
-
+import os, glob
+import math
 import micasense.image as image
 import micasense.panel as panel
-
 
 def test_qr_corners(panel_image_name):
     img = image.Image(panel_image_name)
@@ -42,7 +42,6 @@ def test_qr_corners(panel_image_name):
         assert pt[0] == pytest.approx(good_qr_corners[i][0], abs=3)
         assert pt[1] == pytest.approx(good_qr_corners[i][1], abs=3)
 
-
 def test_panel_corners(panel_image_name):
     img = image.Image(panel_image_name)
     pan = panel.Panel(img)
@@ -56,28 +55,25 @@ def test_panel_corners(panel_image_name):
         assert pt[0] == pytest.approx(good_pts[i][0], abs=3)
         assert pt[1] == pytest.approx(good_pts[i][1], abs=3)
 
-
 # test manually providing bad corners - in this case the corners of the qr code itself
 def test_raw_panel_bad_corners(panel_image_name):
     img = image.Image(panel_image_name)
-    pan = panel.Panel(img, panelCorners=[[460, 599], [583, 599], [584, 478], [462, 477]])
+    pan = panel.Panel(img,panelCorners=[[460, 599], [583, 599], [584, 478], [462, 477]])
     mean, std, num, sat = pan.raw()
     assert mean == pytest.approx(26965, rel=0.01)
     assert std == pytest.approx(15396.0, rel=0.05)
     assert num == pytest.approx(14824, rel=0.01)
     assert sat == pytest.approx(0, abs=2)
 
-
 # test manually providing good corners
 def test_raw_panel_manual(panel_image_name):
     img = image.Image(panel_image_name)
-    pan = panel.Panel(img, panelCorners=[[809, 613], [648, 615], [646, 454], [808, 452]])
+    pan = panel.Panel(img,panelCorners=[[809, 613], [648, 615], [646, 454], [808, 452]])
     mean, std, num, sat = pan.raw()
     assert mean == pytest.approx(45406, rel=0.01)
     assert std == pytest.approx(738.0, rel=0.05)
     assert num == pytest.approx(26005, rel=0.001)
     assert sat == pytest.approx(0, abs=2)
-
 
 def test_raw_panel(panel_image_name):
     img = image.Image(panel_image_name)
@@ -88,7 +84,6 @@ def test_raw_panel(panel_image_name):
     assert num == pytest.approx(26005, rel=0.02)
     assert sat == pytest.approx(0, abs=2)
 
-
 def test_intensity_panel(panel_image_name):
     img = image.Image(panel_image_name)
     pan = panel.Panel(img)
@@ -97,7 +92,6 @@ def test_intensity_panel(panel_image_name):
     assert std == pytest.approx(23, rel=0.03)
     assert num == pytest.approx(26005, rel=0.02)
     assert sat == pytest.approx(0, abs=2)
-
 
 def test_radiance_panel(panel_image_name):
     img = image.Image(panel_image_name)
@@ -108,26 +102,22 @@ def test_radiance_panel(panel_image_name):
     assert num == pytest.approx(26005, rel=0.02)
     assert sat == pytest.approx(0, abs=2)
 
-
 def test_irradiance_mean(panel_image_name):
     img = image.Image(panel_image_name)
     pan = panel.Panel(img)
     panel_reflectance = 0.67
     mean = pan.irradiance_mean(panel_reflectance)
     assert mean == pytest.approx(0.7984, rel=0.001)
-
-
+    
 def test_panel_detected(panel_image_name):
     img = image.Image(panel_image_name)
     pan = panel.Panel(img)
     assert pan.panel_detected() == True
 
-
 def test_panel_not_detected(flight_image_name):
     img = image.Image(flight_image_name)
     pan = panel.Panel(img)
     assert pan.panel_detected() == False
-
 
 def test_altum_panel(altum_panel_image_name):
     img = image.Image(altum_panel_image_name)
@@ -145,27 +135,8 @@ def test_altum_panel(altum_panel_image_name):
         assert pt[1] == pytest.approx(good_pts[i][1], abs=3)
     assert pan.qr_corners() == None
 
-
 def test_altum_lwir(altum_lwir_image_name):
     img = image.Image(altum_lwir_image_name)
     assert img.auto_calibration_image == False
     pan = panel.Panel(img)
     assert pan.panel_detected() == False
-
-
-def test_ordered_coordinates(panel_image_name):
-    img = image.Image(panel_image_name)
-    if img.panel_region is not None:
-        ordered_corners = img.panel_region
-    else:
-        ordered_corners = [(809, 613), (648, 615), (646, 454), (808, 452)]
-    pan = panel.Panel(img, panelCorners=ordered_corners)
-    assert pan.ordered_panel_coordinates() == ordered_corners
-
-
-def test_unordered_coordinates(panel_image_name):
-    img = image.Image(panel_image_name)
-    ordered_corners = [(809, 613), (648, 615), (646, 454), (808, 452)]
-    unordered_corners = [(648, 615), (809, 613), (808, 452), (646, 454)]
-    pan = panel.Panel(img, panelCorners=unordered_corners)
-    assert pan.ordered_panel_coordinates() == ordered_corners


### PR DESCRIPTION
Add method Panel.ordered_panel_coordinates() to return panel region coordinates in a predictable order to mirror ordering found by camera auto-detection.