### PR TITLE
update travis for exiftool 12.01

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ before_install:
   # install library dependencies
   - sudo apt-get install libzbar0 make perl
   # Install exiftool
-  - wget https://www.sno.phy.queensu.ca/~phil/exiftool/Image-ExifTool-11.76.tar.gz
-  - tar -xzf Image-ExifTool-11.76.tar.gz 
-  - pushd Image-ExifTool-11.76/
+  - wget https://exiftool.org/Image-ExifTool-12.01.tar.gz
+  - tar -xzf Image-ExifTool-12.01.tar.gz 
+  - pushd Image-ExifTool-12.01/
   - perl Makefile.PL 
   - make test
   - sudo make install


### PR DESCRIPTION
Quick attempt at fixing a broken Travis build. It seems that Exiftool depreciates old versions, so if this doesn't work we may need to mirror a working version.