### PR TITLE
Fix docstring coordinate order

### DIFF
--- a/micasense/panel.py
+++ b/micasense/panel.py
@@ -195,7 +195,7 @@ class Panel(object):
         """
         Return panel region coordinates in a predictable order. Panel region coordinates that are automatically
         detected by the camera are ordered differently than coordinates detected by Panel.panel_corners().
-        :return: [ (ur), (ul), (ll), (lr) ] to mirror Image.panel_region attribute order
+        :return: [ (lr), (ll), (ul), (ur) ] to mirror Image.panel_region attribute order
         """
         pc = self.panel_corners()
         pc = sorted(pc, key=lambda x: x[0])


### PR DESCRIPTION
Correct docstring coordinate order to `[ (lr), (ll), (ul), (ur) ]`
For reference, here's the coordinates used in `test_panel.py`
`ordered_corners = [(809, 613), (648, 615), (646, 454), (808, 452)]`