### PR TITLE
Update micasense_conda_env.yml

### DIFF
--- a/micasense_conda_env.yml
+++ b/micasense_conda_env.yml
@@ -23,6 +23,6 @@ dependencies:
   - pip:
     - pyzbar
     - mapboxgl
-    - git+https://github.com/smarnach/pyexiftool.git#egg=pyexiftoolpy
+    - git+https://github.com/smarnach/pyexiftool.git#egg=pyexiftool
     - jenkspy
     - rawpy


### PR DESCRIPTION
Line 26 causes Conda env creation to fail:
```
Pip subprocess output:
Collecting pyexiftoolpy
  Cloning https://github.com/smarnach/pyexiftool.git to /tmp/pip-install-iwsds9l6/pyexiftoolpy_27acdf6e025047eeb17c3fd4e3043a6e

Pip subprocess error:
  WARNING: Generating metadata for package pyexiftoolpy produced metadata for project name pyexiftool. Fix your #egg=pyexiftoolpy fragments.
ERROR: Requested pyexiftool from git+https://github.com/smarnach/pyexiftool.git#egg=pyexiftoolpy (from -r /powerplant/workspace/hrrmxj/aerial/imageprocessing/condaenv.7retvuq2.requirements.txt (line 3)) has different name in metadata: 'PyExifTool'
```