### PR TITLE
imageset.py refactor

### DIFF
--- a/micasense/imageset.py
+++ b/micasense/imageset.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python
 # coding: utf-8
 """
-RedEdge Capture Class
+MicaSense ImageSet Class
 
-    A Capture is a set of images taken by one RedEdge cameras which share
-    the same unique capture identifier.  Generally these images will be
-    found in the same folder and also share the same filename prefix, such
-    as IMG_0000_*.tif, but this is not required
+    An ImageSet contains a group of Captures. The Captures can be loaded from Image objects, from a list of files,
+    or by recursively searching a directory for images.
 
 Copyright 2017 MicaSense, Inc.
 
@@ -27,50 +25,136 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-import os, glob, fnmatch
-import micasense.image as image
-import micasense.capture as capture
-from micasense.imageutils import save_capture as save_capture
-import multiprocessing
+
+import fnmatch
+import os
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from functools import partial
+from pprint import pprint
 
 import exiftool
+from tqdm import tqdm
+
+import micasense.capture as capture
+import micasense.image as image
 
 
+# FIXME: mirrors Capture.append_file(). Not used. Does this still belong here?
 def image_from_file(filename):
     return image.Image(filename)
 
+
+def parallel_process(function, iterable, parameters, progress_callback=None, use_tqdm=False):
+    """
+    Multiprocessing Pool handler.
+    :param function: function used in multiprocessing call
+    :param iterable: iterable holding objects passed to function for each process
+    :param parameters: dict of any function parameters other than the iterable object
+    :param use_tqdm: boolean True to use tqdm progress bar
+    :param progress_callback: function to report progress to
+    :return: None
+    """
+
+    with ProcessPoolExecutor() as pool:
+        # run multiprocessing
+        futures = [pool.submit(partial(function, parameters), i) for i in iterable]
+
+        if use_tqdm:
+            # kwargs for tqdm
+            kwargs = {
+                'total': len(futures),
+                'unit': 'Capture',
+                'unit_scale': False,
+                'leave': True
+            }
+
+            # Receive Future objects as they complete. Print out the progress as tasks complete
+            for _ in tqdm(iterable=as_completed(futures), desc='Processing ImageSet', **kwargs):
+                pass
+        elif progress_callback is not None:
+            futures_len = float(len(futures))
+            for i, _ in enumerate(as_completed(futures)):
+                progress_callback(float(i) / futures_len)
+
+
+def save_capture(params, cap):
+    """
+    Process an ImageSet according to program parameters. Saves rgb
+    :param params: dict of program parameters from ImageSet.process_imageset()
+    :param cap: micasense.capture.Capture object
+    """
+    try:
+        # align capture
+        if len(cap.images) == params['capture_len']:
+            cap.create_aligned_capture(
+                irradiance_list=params['irradiance'],
+                warp_matrices=params['warp_matrices'],
+                img_type=params['img_type']
+            )
+        else:
+            print(f"\tCapture {cap.uuid} only has {len(cap.images)} Images. Should have {params['capture_len']}. "
+                  f"Skipping...")
+            return
+
+        if params['output_stack_dir']:
+            output_stack_file_path = os.path.join(params['output_stack_dir'], cap.uuid + '.tif')
+            if params['overwrite'] or not os.path.exists(output_stack_file_path):
+                cap.save_capture_as_stack(output_stack_file_path)
+        if params['output_rgb_dir']:
+            output_rgb_file_path = os.path.join(params['output_rgb_dir'], cap.uuid + '.jpg')
+            if params['overwrite'] or not os.path.exists(output_rgb_file_path):
+                cap.save_capture_as_rgb(output_rgb_file_path)
+
+        cap.clear_image_data()
+    except Exception as e:
+        print(e)
+        pprint(params)
+        quit()
+
+
 class ImageSet(object):
-    """
-    An ImageSet is a container for a group of captures that are processed together
-    """
+    """An ImageSet is a container for a group of Captures that are processed together."""
+
     def __init__(self, captures):
         self.captures = captures
         captures.sort()
-        
+
     @classmethod
-    def from_directory(cls, directory, progress_callback=None, exiftool_path=None):
+    def from_directory(cls, directory, progress_callback=None, use_tqdm=False, exiftool_path=None):
         """
-        Create and ImageSet recursively from the files in a directory
+        Create an ImageSet recursively from the files in a directory.
+        :param directory: str system file path
+        :param progress_callback: function to report progress to
+        :param use_tqdm: boolean True to use tqdm progress bar
+        :param exiftool_path: str system file path to exiftool location
+        :return: ImageSet instance
         """
         cls.basedir = directory
         matches = []
         for root, dirnames, filenames in os.walk(directory):
-            for filename in fnmatch.filter(filenames, '*.tif'):
-                matches.append(os.path.join(root, filename))
+            [matches.append(os.path.join(root, filename)) for filename in fnmatch.filter(filenames, '*.tif')]
 
         images = []
 
-        if exiftool_path is None and os.environ.get('exiftoolpath') is not None:
-            exiftool_path = os.path.normpath(os.environ.get('exiftoolpath'))
+        if use_tqdm:  # to use tqdm progress bar instead of progress_callback
+            with exiftool.ExifTool(exiftool_path) as exift:
+                kwargs = {
+                    'total': len(matches),
+                    'unit': ' Files',
+                    'unit_scale': False,
+                    'leave': True
+                }
+                for path in tqdm(iterable=matches, desc='Loading ImageSet', **kwargs):
+                    images.append(image.Image(path, exiftool_obj=exift))
+        else:
+            with exiftool.ExifTool(exiftool_path) as exift:
+                print('Loading ImageSet from: {}'.format(directory))
+                for i, path in enumerate(matches):
+                    images.append(image.Image(path, exiftool_obj=exift))
+                    if progress_callback is not None:
+                        progress_callback(float(i) / float(len(matches)))
 
-        with exiftool.ExifTool(exiftool_path) as exift:
-            for i,path in enumerate(matches):
-                images.append(image.Image(path, exiftool_obj=exift))
-                if progress_callback is not None:
-                    progress_callback(float(i)/float(len(matches)))
-
-        # create a dictionary to index the images so we can sort them
-        # into captures
+        # create a dictionary to index the images so we can sort them into captures
         # {
         #     "capture_id": [img1, img2, ...]
         # }
@@ -89,61 +173,110 @@ class ImageSet(object):
         if progress_callback is not None:
             progress_callback(1.0)
         return cls(captures)
-    
+
     def as_nested_lists(self):
+        """
+        Get timestamp, latitude, longitude, altitude, capture_id, dls-yaw, dls-pitch, dls-roll, irradiance from all
+        Captures.
+        :return: List data from all Captures, List column headers.
+        """
         columns = [
             'timestamp',
-            'latitude','longitude','altitude',
+            'latitude', 'longitude', 'altitude',
             'capture_id',
-            'dls-yaw','dls-pitch','dls-roll'
+            'dls-yaw', 'dls-pitch', 'dls-roll'
         ]
         irr = ["irr-{}".format(wve) for wve in self.captures[0].center_wavelengths()]
         columns += irr
-        data = [] 
+        data = []
         for cap in self.captures:
             dat = cap.utc_time()
             loc = list(cap.location())
             uuid = cap.uuid
             dls_pose = list(cap.dls_pose())
             irr = cap.dls_irradiance()
-            row = [dat]+loc+[uuid]+dls_pose+irr
+            row = [dat] + loc + [uuid] + dls_pose + irr
             data.append(row)
         return data, columns
 
     def dls_irradiance(self):
+        """
+        Get utc_time and irradiance for each Capture in ImageSet.
+        :return: dict {utc_time : [irradiance, ...]}
+        """
         series = {}
         for cap in self.captures:
             dat = cap.utc_time().isoformat()
             irr = cap.dls_irradiance()
             series[dat] = irr
+        return series
 
-    def save_stacks(self, warp_matrices, stackDirectory, thumbnailDirectory=None, irradiance=None, multiprocess=True, overwrite=False, progress_callback=None):
-        
-        if not os.path.exists(stackDirectory):
-            os.makedirs(stackDirectory)
-        if thumbnailDirectory is not None and not os.path.exists(thumbnailDirectory):
-            os.makedirs(thumbnailDirectory)
+    def process_imageset(self,
+                         output_stack_directory=None,
+                         output_rgb_directory=None,
+                         warp_matrices=None,
+                         irradiance=None,
+                         img_type=None,
+                         multiprocess=True,
+                         overwrite=False,
+                         progress_callback=None,
+                         use_tqdm=False):
+        """
+        Write band stacks and rgb thumbnails to disk.
+        :param warp_matrices: 2d List of warp matrices derived from Capture.get_warp_matrices()
+        :param output_stack_directory: str system file path to output stack directory
+        :param output_rgb_directory: str system file path to output thumbnail directory
+        :param irradiance: List returned from Capture.dls_irradiance() or Capture.panel_irradiance()    <-- TODO: Write a better docstring for this
+        :param img_type: str 'radiance' or 'reflectance'. Desired image output type.
+        :param multiprocess: boolean True to use multiprocessing module
+        :param overwrite: boolean True to overwrite existing files
+        :param progress_callback: function to report progress to
+        :param use_tqdm: boolean True to use tqdm progress bar
+        """
 
-        save_params_list = []
-        for capture in self.captures:
-            save_params_list.append({
-                'output_path': stackDirectory,
-                'thumbnail_path': thumbnailDirectory,
-                'file_list': [img.path for img in capture.images],
-                'warp_matrices': warp_matrices,
-                'irradiance_list': irradiance,
-                'photometric': 'MINISBLACK',
-                'overwrite_existing': overwrite,
-            })
+        # ensure some output is requested
+        if output_stack_directory is None and output_rgb_directory is None:
+            raise RuntimeError('No output requested for the ImageSet.')
 
+        # make output dirs if not exist
+        if output_stack_directory is not None and not os.path.exists(output_stack_directory):
+            os.mkdir(output_stack_directory)
+        if output_rgb_directory is not None and not os.path.exists(output_rgb_directory):
+            os.mkdir(output_rgb_directory)
+
+        # processing parameters
+        params = {
+            'warp_matrices': warp_matrices,
+            'irradiance': irradiance,
+            'img_type': img_type,
+            'capture_len': len(self.captures[0].images),
+            'output_stack_dir': output_stack_directory,
+            'output_rgb_dir': output_rgb_directory,
+            'overwrite': overwrite,
+        }
+
+        print('Processing {} Captures ...'.format(len(self.captures)))
+
+        # multiprocessing with concurrent futures
         if multiprocess:
-            pool = multiprocessing.Pool(processes=multiprocessing.cpu_count())
-            for i,_ in enumerate(pool.imap_unordered(save_capture, save_params_list)):
-                if progress_callback is not None:
-                    progress_callback(float(i)/float(len(save_params_list)))
-            pool.close()
-            pool.join()
-        else:
-            for params in save_params_list:
-                save_capture(params)
+            parallel_process(function=save_capture, iterable=self.captures, parameters=params,
+                             progress_callback=progress_callback, use_tqdm=use_tqdm)
 
+        # else serial processing
+        else:
+            if use_tqdm:
+                kwargs = {
+                    'total': len(self.captures),
+                    'unit': 'Capture',
+                    'unit_scale': False,
+                    'leave': True
+                }
+                for cap in tqdm(iterable=self.captures, desc='Processing ImageSet', **kwargs):
+                    save_capture(params, cap)
+            else:
+                for i, cap in enumerate(self.captures):
+                    save_capture(params, cap)
+                    if progress_callback is not None:
+                        progress_callback(float(i) / float(len(self.captures)))
+
+        print('Processing complete.')

--- a/micasense/imageset.py
+++ b/micasense/imageset.py
@@ -133,9 +133,14 @@ class ImageSet(object):
         :return: ImageSet instance
         """
 
+        # progress_callback deprecation warning
         if progress_callback is not None:
             warnings.warn(message='The progress_callback parameter will be deprecated in favor of use_tqdm',
                           category=PendingDeprecationWarning)
+
+        # ensure exiftoolpath is found per MicaSense setup instructions
+        if exiftool_path is None and os.environ.get('exiftoolpath') is not None:
+            exiftool_path = os.path.normpath(os.environ.get('exiftoolpath'))
 
         cls.basedir = directory
         matches = []

--- a/micasense/imageutils.py
+++ b/micasense/imageutils.py
@@ -418,21 +418,3 @@ def map_points(pts, image_size, warpMatrix, distortion_coeffs, camera_matrix,war
     else:
         return new_pts[:,0,:]
 
-def save_capture(params):
-    import micasense.capture as capture
-    cap = capture.Capture.from_filelist(params['file_list'])
-    outputFilename = cap.uuid+'.tif'
-    if(os.path.exists(outputFilename) and params['overwrite_existing']==False):
-        return outputFilename
-
-    fullOutputPath = os.path.join(params['output_path'], outputFilename)
-    cap.create_aligned_capture(irradiance_list=params['irradiance_list'], warp_matrices=params['warp_matrices'])
-    cap.save_capture_as_stack(fullOutputPath, sort_by_wavelength=True, photometric=params['photometric'])
-
-    if params['thumbnail_path'] is not None:
-        thumbnailFilename = cap.uuid
-        fullThumbnailPath= os.path.join(params['thumbnail_path'], thumbnailFilename)
-        rgb_band_indices = [cap.band_names_lower().index('red'),cap.band_names_lower().index('green'),cap.band_names_lower().index('blue')]
-        cap.save_capture_as_rgb(fullThumbnailPath+'_rgb.jpg', rgb_band_indices = rgb_band_indices, gamma=1.8) # original indices, not sorted
-
-    return outputFilename

--- a/micasense_conda_env.yml
+++ b/micasense_conda_env.yml
@@ -18,6 +18,7 @@ dependencies:
   - pip
   - requests
   - packaging
+  - tqdm
   - pip:
       - pysolar
       - pyzbar

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import codecs
 from setuptools import setup, find_packages
-import os
 
 # Parse the version from the main __init__.py
 with open('micasense/__init__.py') as f:
@@ -33,6 +31,6 @@ setup(name='micasense',
           'packaging',
           'pyexiftool',
           'pytz',
-          'pyzbar'
+          'pyzbar',
+          'tqdm'
       ])
-


### PR DESCRIPTION
First cut at a imageset.py refactor, to better expose the high level code.

- Starts to fix #77. [This](https://github.com/micasense/imageprocessing/issues/77#issuecomment-620129409) comment.
- Refactor `save_capture()` to `ImageSet` class proper. It's not called from anywhere else so the logic seems better. Especially since `Capture` has these methods built in.
- Add return value to `dls_irradiance()`. I don't think this is used anywhere though.
- Add docstrings and PEP8 cleanup
- Add [tqdm](https://tqdm.github.io/) progess bar

TODO:
- Delete `image_from_file()`? Seems unused.
- Better docstring for irradiance input. Even after reading the tutorials this is still a little unclear. Maybe candidate to expand tutorials.