### PR TITLE
Add save_capture_as_bands() method. Add out_data_type parameter.

### DIFF
--- a/micasense/capture.py
+++ b/micasense/capture.py
@@ -586,8 +586,9 @@ class Capture(object):
                 # scale data from float degC to back to centi-Kelvin to fit into uint16
                 out_data = (self.__aligned_capture[:, :, in_band] + 273.15) * 100 if gdal_type == 2 \
                     else self.__aligned_capture[:, :, in_band]
-                out_data[out_data < 0] = 0
-                out_data[out_data > 65535] = 65535
+                if gdal_type == 2:
+                    out_data[out_data < 0] = 0
+                    out_data[out_data > 65535] = 65535
                 out_band.WriteArray(out_data)
                 out_band.FlushCache()
         finally:
@@ -651,6 +652,9 @@ class Capture(object):
             # if GDT_UInt16, scale data from float degC to back to centi-Kelvin to fit into UInt16.
             out_data = (self.__aligned_capture[:, :, i] + 273.15) * 100 if gdal_type == 2 \
                 else self.__aligned_capture[:, :, i]
+            if gdal_type == 2:
+                out_data[out_data < 0] = 0
+                out_data[out_data > 65535] = 65535
             out_band.WriteArray(out_data)
             out_band.FlushCache()
 


### PR DESCRIPTION
The scope of this PR was a little broader than expected.

The unanticipated challenge when allowing multiple output data types is that handling the `img_type is None` case creates too many logical branches and the standard `if else` clutter for no real benefit. The simplest thing to do was change `img_type` from a `kwarg` to a positional argument. Forcing the choice works because there are only 2 potential outputs, and handling the `None` case with available data just felt like it added confusion especially in the higher level ImageSet.

This PR:
- Change `Capture.create_aligned_capture()` to accept `img_type` as a positional argument. Simplify radiance/reflectance logic.
- Adds `Capture.save_capture_as_bands()` to meet the original intent. This includes output data type handling, and simplified logic depending on whether user passes `'radiance'` or '`reflectance'` value.
- Update `Capture.save_capture_as_stack() to also accept the new output data type handling.
- Update `ImageSet` to accomodate output data type parameter. Also update `img_type` to positional argument to match `Capture` usage. Some docstring improvements.
