### PR TITLE
Fix RP 06 panel detection

### DIFF
--- a/data/0002SET/000/IMG_0183_1.tif
+++ b/data/0002SET/000/IMG_0183_1.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:355a1a43555ef9e6319ba68241c0aabe002531847c0170105ef8f190a1d53f96
+size 2465968

--- a/data/0002SET/000/IMG_0183_2.tif
+++ b/data/0002SET/000/IMG_0183_2.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0d9926375c832b670bb31a064c3fc28aa98343e0117877f0b82f505c19b293c
+size 2465966

--- a/data/0002SET/000/IMG_0183_3.tif
+++ b/data/0002SET/000/IMG_0183_3.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d2bce2d536c20ce229b92eb6157d8a41317ea9ed8af0098d955acdf67382610
+size 2465972

--- a/data/0002SET/000/IMG_0183_4.tif
+++ b/data/0002SET/000/IMG_0183_4.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f80dbc0284b5561d3144b27866048d0cebda4a050072eee744b03ab8a288ff4
+size 2465966

--- a/data/0002SET/000/IMG_0183_5.tif
+++ b/data/0002SET/000/IMG_0183_5.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfeb85a03c99ce1712a48ef127b9f0719bfdc01323989f4a1bc17c4bf173cdc4
+size 2465962

--- a/micasense/panel.py
+++ b/micasense/panel.py
@@ -157,25 +157,52 @@ class Panel(object):
             return None
         
         if self.panel_version < 3:
-            reference_panel_pts = np.asarray([[894, 469], [868, 232], [630, 258], [656, 496]], 
-                                            dtype=np.int32)
-            reference_qr_pts = np.asarray([[898, 748], [880, 567], [701, 584], [718, 762]], 
-                                        dtype=np.int32)
-        elif self.panel_version >= 3:
-            reference_panel_pts = np.asarray([[557, 350], [550, 480], [695, 480], [700, 350]], dtype=np.int32)
-            reference_qr_pts = np.asarray([[821, 324], [819, 506], [996, 509], [999, 330]], dtype=np.int32) 
-
+            # reference_panel_pts = np.asarray([[894, 469], [868, 232], [630, 258], [656, 496]], 
+            #                                 dtype=np.int32)
+            # reference_qr_pts = np.asarray([[898, 748], [880, 567], [701, 584], [718, 762]], 
+            #                             dtype=np.int32)
+            
+            # use the actual panel measures here - we use units of [mm]
+            # the panel is 154.4 x 152.4 mm , vs. the 84 x 84 mm for the QR code
+            # it is left 143.20 mm from the QR code 
+            # use the inner 50% square of the panel
+            s = 76.2
+            p = 42
+            T = np.array([-143.2,0])
+            
+        elif (self.panel_version >= 3) and (self.panel_version<6):
+            s = 50
+            p = 45
+            T = np.array([-145.8,0])
+            # reference_panel_pts = np.asarray([[557, 350], [550, 480], [695, 480], [700, 350]], dtype=np.int32)
+            # reference_qr_pts = np.asarray([[821, 324], [819, 506], [996, 509], [999, 330]], dtype=np.int32) 
+        elif self.panel_version >= 6 :
+            # use the actual panel measures here - we use units of [mm]
+            # the panel is 100 x 100 mm , vs. the 91 x 91 mm for the QR code
+            # it is down 125.94 mm from the QR code 
+            # use the inner 50% square of the panel
+            p = 41
+            s = 50
+            T = np.array([0,-130.84])
+           
+                     
+        reference_panel_pts = np.asarray([[-s, s], [s, s], [s, -s], [-s, -s]], dtype=np.float32)*.5+T
+        reference_qr_pts = np.asarray([[-p, p], [p, p], [p, -p], [-p, -p]], dtype=np.float32)
         bounds = []
         costs = []
         for rotation in range(0,4):
             qr_points = np.roll(reference_qr_pts, rotation, axis=0)
 
-            src = np.asarray([tuple(row) for row in qr_points[:3]], np.float32)
-            dst = np.asarray([tuple(row) for row in self.qr_corners()[:3]], np.float32)
-            warp_matrix = cv2.getAffineTransform(src, dst)
+            src = np.asarray([tuple(row) for row in qr_points[:]], np.float32)
+            dst = np.asarray([tuple(row) for row in self.qr_corners()[:]], np.float32)
+            
+            # we determine the homography from the 4 corner points
+            warp_matrix = cv2.getPerspectiveTransform(src,dst)
+            
+            #warp_matrix = cv2.getAffineTransform(src, dst)
 
-            pts = np.asarray([reference_panel_pts], 'int32')
-            panel_bounds = cv2.convexHull(cv2.transform(pts, warp_matrix), clockwise=False)
+            pts = np.asarray([reference_panel_pts], 'float32')
+            panel_bounds = cv2.convexHull(cv2.perspectiveTransform(pts, warp_matrix), clockwise=False)
             panel_bounds = np.squeeze(panel_bounds) # remove nested lists
             
             bounds_in_image = True
@@ -184,7 +211,7 @@ class Panel(object):
                     bounds_in_image = False
             if bounds_in_image:
                 mean, std, _, _ = self.region_stats(self.image.raw(),panel_bounds, sat_threshold=65000)
-                bounds.append(panel_bounds)
+                bounds.append(panel_bounds.astype(np.int32))
                 costs.append(std/mean)
 
         idx = costs.index(min(costs))
@@ -195,7 +222,7 @@ class Panel(object):
         """
         Return panel region coordinates in a predictable order. Panel region coordinates that are automatically
         detected by the camera are ordered differently than coordinates detected by Panel.panel_corners().
-        :return: [ (lr), (ll), (ul), (ur) ] to mirror Image.panel_region attribute order
+        :return: [ (ur), (ul), (ll), (lr) ] to mirror Image.panel_region attribute order
         """
         pc = self.panel_corners()
         pc = sorted(pc, key=lambda x: x[0])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,17 @@ def panel_image_name_red():
     return os.path.join(image_path, 'IMG_0000_2.tif')
 
 @pytest.fixture()
+def panel_image_name_RP06_blue():
+    image_path = os.path.join('data', '0002SET', '000')
+    return os.path.join(image_path, 'IMG_0183_1.tif')
+
+@pytest.fixture()
+def panel_images_RP06():
+    image_path = os.path.join('data', '0002SET', '000')
+    return glob.glob(os.path.join(image_path, 'IMG*.tif'))
+
+
+@pytest.fixture()
 def flight_image_name():
     image_path = os.path.join('data', '0000SET', '000')
     return os.path.join(image_path, 'IMG_0001_1.tif')

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -125,7 +125,7 @@ def test_panel_radiance(panel_rededge_capture):
                     0.13081077851565506]
     assert len(rad) == len(expected_rad)
     for i,_ in enumerate(expected_rad):
-        assert rad[i] == pytest.approx(expected_rad[i], rel=0.001)
+        assert rad[i] == pytest.approx(expected_rad[i], rel=0.01)
 
 def test_panel_raw(panel_rededge_capture):
     raw = panel_rededge_capture.panel_raw()
@@ -137,7 +137,7 @@ def test_panel_raw(panel_rededge_capture):
                     54479.170371812339]
     assert len(raw) == len(expected_raw)
     for i,_ in enumerate(expected_raw):
-        assert raw[i] == pytest.approx(expected_raw[i], rel=0.001)
+        assert raw[i] == pytest.approx(expected_raw[i], rel=0.01)
 
 def test_panel_irradiance(panel_rededge_capture):
     panel_reflectance_by_band = [0.67, 0.69, 0.68, 0.61, 0.67]
@@ -145,7 +145,7 @@ def test_panel_irradiance(panel_rededge_capture):
     expected_rad = [0.79845135523772681, 0.81681533164998943, 0.74944205649335915, 0.54833776619262586, 0.61336444894797537]
     assert len(rad) == len(expected_rad)
     for i,_ in enumerate(expected_rad):
-        assert rad[i] == pytest.approx(expected_rad[i], rel=0.001)
+        assert rad[i] == pytest.approx(expected_rad[i], rel=0.01)
 
 def test_panel_albedo_not_preset(panel_rededge_capture):
     assert panel_rededge_capture.panels_in_all_expected_images()

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -30,6 +30,27 @@ import micasense.image as image
 import micasense.panel as panel
 import operator
 
+def test_RP06_panel_ID(panel_image_name_RP06_blue):
+    img = image.Image(panel_image_name_RP06_blue)
+    pan = panel.Panel(img)
+    qr_corners = pan.qr_corners()
+    assert pan.panel_version == 6
+    
+def test_RP06_panel_raw(panel_images_RP06):
+    test_mean = [41064,39046,42419,35149,37266]
+    test_std = [680,534,560,607,507]
+    test_num = [2543,2100,2408,2484,2358]
+    test_sat = [0,0,0,0,0]
+    for i,m,s,n,sa in zip(panel_images_RP06,test_mean,test_std,test_num,test_sat):
+         img = image.Image(i)
+         pan = panel.Panel(img)
+         mean, std, num, sat = pan.raw()
+         print('mean {:f} std {:f} num {:f} sat {:f}'.format(mean,std,num,sat))
+         assert mean == pytest.approx(m,rel=0.1)
+         assert std == pytest.approx(s,rel=0.1)
+         assert num == pytest.approx(n,rel=0.1)
+         assert sat == pytest.approx(sa,rel=0.1)
+
 def test_qr_corners(panel_image_name):
     img = image.Image(panel_image_name)
     pan = panel.Panel(img)
@@ -47,7 +68,8 @@ def test_panel_corners(panel_image_name):
     img = image.Image(panel_image_name)
     pan = panel.Panel(img)
     panel_pts = pan.panel_corners()
-    good_pts = [[809, 613], [648, 615], [646, 454], [808, 452]]
+    good_pts = [[785,594],[674,593],[673,483],[783,484]]
+
     assert panel_pts is not None
     assert len(panel_pts) == len(good_pts)
     assert pan.serial == 'RP02-1603036-SC'
@@ -102,8 +124,8 @@ def test_raw_panel(panel_image_name):
     pan = panel.Panel(img)
     mean, std, num, sat = pan.raw()
     assert mean == pytest.approx(45406.0, rel=0.01)
-    assert std == pytest.approx(738.0, rel=0.05)
-    assert num == pytest.approx(26005, rel=0.02)
+    assert std == pytest.approx(689.0, rel=0.05)
+    assert num == pytest.approx(12154, rel=0.02)
     assert sat == pytest.approx(0, abs=2)
 
 def test_intensity_panel(panel_image_name):
@@ -111,8 +133,8 @@ def test_intensity_panel(panel_image_name):
     pan = panel.Panel(img)
     mean, std, num, sat = pan.intensity()
     assert mean == pytest.approx(1162, rel=0.01)
-    assert std == pytest.approx(23, rel=0.03)
-    assert num == pytest.approx(26005, rel=0.02)
+    assert std == pytest.approx(20, rel=0.03)
+    assert num == pytest.approx(12154, rel=0.02)
     assert sat == pytest.approx(0, abs=2)
 
 def test_radiance_panel(panel_image_name):
@@ -120,8 +142,8 @@ def test_radiance_panel(panel_image_name):
     pan = panel.Panel(img)
     mean, std, num, sat = pan.radiance()
     assert mean == pytest.approx(0.170284, rel=0.01)
-    assert std == pytest.approx(0.0033872969661854742, rel=0.02)
-    assert num == pytest.approx(26005, rel=0.02)
+    assert std == pytest.approx(0.0029387953691472554, rel=0.02)
+    assert num == pytest.approx(12154, rel=0.02)
     assert sat == pytest.approx(0, abs=2)
 
 def test_irradiance_mean(panel_image_name):
@@ -129,7 +151,7 @@ def test_irradiance_mean(panel_image_name):
     pan = panel.Panel(img)
     panel_reflectance = 0.67
     mean = pan.irradiance_mean(panel_reflectance)
-    assert mean == pytest.approx(0.7984, rel=0.001)
+    assert mean == pytest.approx(0.7984, rel=0.01)
     
 def test_panel_detected(panel_image_name):
     img = image.Image(panel_image_name)


### PR DESCRIPTION
This modification uses the physical location of the reflectance panel from the actual drawings vs. approximate pixel coordinates - the inner 50% of the panel area is used for all subsequent calculations. 

This change has been implemented for all panel versions.

Changed the transform to a homography.

Added 5 new panel images of the RP06 panel to the unit tests and two new unit tests, which test for correct identification of the panel and the correct raw values, i.e. mean, std, number of pixels and saturated. Also changed the unit tests to work with the RP<6 panels with the new methods.