### PR TITLE
Bugfix/metadata utctime error negative subsec

### DIFF
--- a/data/REDEDGE-MX/IMG_0008_1.tif
+++ b/data/REDEDGE-MX/IMG_0008_1.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15cf9db7229da923c4b1c71936c3f24a24c4a7543bd0cb3d5837433f4643dfb5
+size 2465384

--- a/data/REDEDGE-MX/IMG_0008_2.tif
+++ b/data/REDEDGE-MX/IMG_0008_2.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50d05497f145bdce93ef5d3ecdb60e46e05e1aa18221843f56de91f54f2eccb3
+size 2465404

--- a/data/REDEDGE-MX/IMG_0008_3.tif
+++ b/data/REDEDGE-MX/IMG_0008_3.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eed65118e9b54e1a15461373e8904be307aef3e02ba37b31d2d19f541185d0c0
+size 2465382

--- a/data/REDEDGE-MX/IMG_0008_4.tif
+++ b/data/REDEDGE-MX/IMG_0008_4.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e74b7d6fe2b7e1bca2705a0b528c08ff5b92fd99b23dc3ae00c7d5b9f5661295
+size 2465394

--- a/data/REDEDGE-MX/IMG_0008_5.tif
+++ b/data/REDEDGE-MX/IMG_0008_5.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:536683a2010a3611ab2bb41f529cc2c0f03a9c30640b3239adc6df7487a4442e
+size 2465380

--- a/micasense/metadata.py
+++ b/micasense/metadata.py
@@ -128,11 +128,12 @@ class Metadata(object):
         str_time = self.get_item('EXIF:DateTimeOriginal')
         if str_time:
             utc_time = datetime.strptime(str_time, "%Y:%m:%d %H:%M:%S")
-            subsec = float(f"0.{self.get_item('EXIF:SubSecTime')}")
+            subsec = int(self.get_item('EXIF:SubSecTime'))
             negative = 1.0
             if subsec < 0:
                 negative = -1.0
                 subsec *= -1.0
+            subsec = float(f"0.{int(subsec)}")
             subsec *= negative
             ms = subsec * 1e3
             utc_time += timedelta(milliseconds=ms)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,3 +195,7 @@ def meta_bad_exposure(rededge_files_dir: Path):
 @pytest.fixture()
 def meta_altum_dls2(altum_flight_image_name):
     return metadata.Metadata(altum_flight_image_name)
+
+@pytest.fixture()
+def meta_negative_subsec(rededge_files_dir: Path):
+    return metadata.Metadata(str(rededge_files_dir / 'IMG_0008_1.tif'))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -67,6 +67,11 @@ def test_utc_time(meta):
     assert utc_time is not None
     assert utc_time.strftime('%Y-%m-%d %H:%M:%S.%f') == '2022-04-06 18:50:25.983430'
 
+def test_utc_time_negative_subsec(meta_negative_subsec):
+    utc_time = meta_negative_subsec.utc_time()
+    assert utc_time is not None
+    assert utc_time.strftime('%Y-%m-%d %H:%M:%S.%f') == '2018-07-25 05:53:52.762886'
+
 
 def test_position(meta):
     assert meta.position() == pytest.approx((47.7036143, -122.1414373, 6.728))


### PR DESCRIPTION
Casting f"0.self.get_time('EXIF:SubSecTime')" directly causes ValueError as the string to be casted is in the format '0.-nnnnnn'.