### PR TITLE
remove deprecated exiftool path

### DIFF
--- a/MicaSense Image Processing Tutorial 1.ipynb
+++ b/MicaSense Image Processing Tutorial 1.ipynb
@@ -104,7 +104,7 @@
     "if os.name == 'nt':\n",
     "    exiftoolPath = os.environ.get('exiftoolpath')\n",
     "# get image metadata\n",
-    "meta = metadata.Metadata(panelImageName, exiftool_path=exiftoolPath)\n",
+    "meta = metadata.Metadata(panelImageName)\n",
     "cameraMake = meta.get_item('EXIF:Make')\n",
     "cameraModel = meta.get_item('EXIF:Model')\n",
     "firmwareVersion = meta.get_item('EXIF:Software')\n",

--- a/micasense/imageset.py
+++ b/micasense/imageset.py
@@ -52,7 +52,7 @@ class ImageSet(object):
         captures.sort()
 
     @classmethod
-    def from_directory(cls, directory, progress_callback=None, exiftool_path=None, allow_uncalibrated=False):
+    def from_directory(cls, directory, progress_callback=None, allow_uncalibrated=False):
         """
         Create and ImageSet recursively from the files in a directory
         """
@@ -64,10 +64,7 @@ class ImageSet(object):
 
         images = []
 
-        if exiftool_path is None and os.environ.get('exiftoolpath') is not None:
-            exiftool_path = os.path.normpath(os.environ.get('exiftoolpath'))
-
-        with exiftool.ExifToolHelper(exiftool_path) as exift:
+        with exiftool.ExifToolHelper() as exift:
             for i, path in enumerate(matches):
                 images.append(image.Image(path, exiftool_obj=exift, allow_uncalibrated=allow_uncalibrated))
                 if progress_callback is not None:

--- a/micasense/metadata.py
+++ b/micasense/metadata.py
@@ -36,16 +36,11 @@ import pytz
 class Metadata(object):
     """ Container for Micasense image metadata"""
 
-    def __init__(self, filename: str, exiftool_path=None, exiftool_obj=None):
+    def __init__(self, filename: str, exiftool_obj=None):
         if exiftool_obj is not None:
             self.exif = exiftool_obj.get_metadata(filename)
             return
-        if exiftool_path is not None:
-            self.exiftoolPath = exiftool_path
-        elif os.environ.get('exiftoolpath') is not None:
-            self.exiftoolPath = os.path.normpath(os.environ.get('exiftoolpath'))
-        else:
-            self.exiftoolPath = None
+
         if not os.path.isfile(filename):
             raise IOError("Input path is not a file")
         with exiftool.ExifToolHelper() as exift:


### PR DESCRIPTION
This fixes #209 to consistently remove the `exiftool_path`